### PR TITLE
Add azure support to bcbio version of elasticluster

### DIFF
--- a/README-AZURE.rst
+++ b/README-AZURE.rst
@@ -16,13 +16,13 @@ that is https://github.com/alexandrucoman/vagrant-environment. This document des
 support, but the same concepts (and troubleshooting tips) apply.
 
 Note about pip (6/19/15): There is a bug in the Ubuntu version of pip at this time. (see
-https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1306991) If you encounter this bug, the command ``pip install --pre azure-elasticluster`` will fail.
+https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1306991) If you encounter this bug, the command ``pip install --pre elasticluster`` will fail.
 At that point, if you try to run the ``pip`` command by itself, that will also fail. The solution is as follows:
 ::
 
 	sudo easy_install -U pip	# this will uninstall and reinstall pip, without the problem
-	sudo pip uninstall elasticluster	# note, that's NOT azure-elasticluster, just elasticluster
-	sudo pip install --pre azure-elasticluster
+	sudo pip uninstall elasticluster
+	sudo pip install --pre --no-use-wheel elasticluster
 
 
 Notes about this version: The basis for this code is elasticluster 1.3.dev0 (which is known to be compatible with bcbio_vm at this time).
@@ -48,6 +48,8 @@ In this guide, we'll walk through all the steps to:
 		libssl-dev libffi-dev nodejs-legacy
 	sudo apt-get install npm -y
 	sudo apt-get install libxml2-dev libxslt1-dev
+    sudo pip install --upgrade httplib2
+    sudo pip install --upgrade stevedore
 	# these two steps are only needed if you want to run in a virtual Python environment:
 	sudo apt-get install python-virtualenv
 	sudo pip install virtualenvwrapper
@@ -78,9 +80,9 @@ do NOT specify ``sudo`` in the following command. If not in a virtual environmen
 
 ::
 
-	sudo pip install --pre azure-elasticluster
+	sudo pip install --pre --no-use-wheel elasticluster
 
-The Microsoft Azure SDK for Python will be automatically installed by the azure-elasticluster package. For more 
+The Microsoft Azure SDK for Python will be automatically installed by the elasticluster package. For more 
 information see: https://github.com/Azure/azure-sdk-for-python/
 
 4. Confirm elasticluster is ready to run:

--- a/README-AZURE.rst
+++ b/README-AZURE.rst
@@ -1,0 +1,237 @@
+========================================================================
+Testing gridengine + elasticluster + Azure
+========================================================================
+
+.. This file follows reStructuredText markup syntax; see
+   http://docutils.sf.net/rst.html for more information
+
+
+Dave Steinkraus / Trevor Eberl 6/29/2015
+
+This document, and the Azure provider for elasticluster, are works in progress. Expect changes.
+
+Bcbio_vm note: This version of Azure support for elasticluster is intended for use with bcbio_vm. It is minimally changed from the fork at
+https://github.com/chapmanb/elasticluster/. This document does not discuss integration of Azure support with bcbio_vm; one resource for
+that is https://github.com/alexandrucoman/vagrant-environment. This document describes standalone installation of elasticluster with Azure
+support, but the same concepts (and troubleshooting tips) apply.
+
+Note about pip (6/19/15): There is a bug in the Ubuntu version of pip at this time. (see
+https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1306991) If you encounter this bug, the command ``pip install --pre azure-elasticluster`` will fail.
+At that point, if you try to run the ``pip`` command by itself, that will also fail. The solution is as follows:
+::
+
+	sudo easy_install -U pip	# this will uninstall and reinstall pip, without the problem
+	sudo pip uninstall elasticluster	# note, that's NOT azure-elasticluster, just elasticluster
+	sudo pip install --pre azure-elasticluster
+
+
+Notes about this version: The basis for this code is elasticluster 1.3.dev0 (which is known to be compatible with bcbio_vm at this time).
+This is not the current version of elasticluster. Another branch/PyPI package will be created based on the current version.
+
+This older version of elasticluster is not compatible with the latest Ansible. So, setup.py for this project requires Ansible 1.7.2.
+
+The azure-ansible fork of Ansible is no longer needed, and should be uninstalled if present.
+
+In this guide, we'll walk through all the steps to:
+
+	- set up a Linux machine to run a test version of elasticluster that supports Microsoft Azure; 
+	- start an Azure compute cluster and provision it to run gridengine; 
+	- communicate with the cluster; and 
+	- tear down the cluster.
+
+1. Set up a client environment for running elasticluster. Most testing has been done on Ubuntu 14.04, so this is recommended. On a new machine, install prerequisites:
+
+::
+
+	sudo apt-get update
+	sudo apt-get install git python-pip python-dev build-essential \
+		libssl-dev libffi-dev nodejs-legacy
+	sudo apt-get install npm -y
+	sudo apt-get install libxml2-dev libxslt1-dev
+	# these two steps are only needed if you want to run in a virtual Python environment:
+	sudo apt-get install python-virtualenv
+	sudo pip install virtualenvwrapper
+
+2. If you wish, create and enter a virtual Python environment. If installing on a computer that is also used for other purposes, 
+this is strongly recommended, since you will be installing a nonstandard fork of elasticluster, and keeping the system Python clean
+is a good general practice. If installing on a computer (or virtual machine) that is dedicated to this task, you can skip to step 3:
+
+::
+
+	mkdir ~/.virtualenvs
+	export WORKON_HOME=~/.virtualenvs
+	source /usr/local/bin/virtualenvwrapper.sh
+	mkvirtualenv elasticluster
+	workon elasticluster
+	cdvirtualenv
+	# note that the following command will make the wrapper commands (workon, etc.) available in the future:
+	# echo "source /usr/local/bin/virtualenvwrapper.sh" >> $HOME/.bashrc
+
+3. Install the specific Python packages for this test scenario:
+
+This is the forked version of elasticluster that supports Azure (for testing prior to integration with elsticluster).
+(NOTE: A previous version of this code required a special version of Ansible. This is no longer the case.)
+In spite of the different PyPI name here, the package actually installed will be named ``elasticluster``, so if you also need to run
+the standard version of elasticluster on the same computer, you should use a virtual environment for this one. 
+The ``--pre`` flag is needed because this is labeled as a "dev" version in PyPI. NOTE: If you are in a virtual environment, 
+do NOT specify ``sudo`` in the following command. If not in a virtual environment, you MUST specify ``sudo``.
+
+::
+
+	sudo pip install --pre azure-elasticluster
+
+The Microsoft Azure SDK for Python will be automatically installed by the azure-elasticluster package. For more 
+information see: https://github.com/Azure/azure-sdk-for-python/
+
+4. Confirm elasticluster is ready to run:
+
+::
+
+	elasticluster --help
+
+5. You'll need to have an Azure account and know its subscription ID. (see http://azure.microsoft.com/en-us/ to set up a 30-day trial account if necessary.) 
+You'll also need to generate a management certificate (.cer) and upload it to Azure. If you haven't done this yet:
+
+::
+
+	mkdir ~/.ssh
+	chmod 700 ~/.ssh
+
+Here's one of those things that shouldn't matter, but it apparently does: you should run the following openssl commands from the ``~/.ssh`` 
+directory. (Or maybe it's OK if you always use absolute paths instead of "~", but that's unconfirmed at this point.) If you don't do this, 
+the resulting keys will not work - Azure will accept them, but Ansible won't, so your VMs will start and then fail to be provisioned.
+
+::
+
+	cd ~/.ssh
+
+The next command will prompt for information. Set the company name as it will make finding the cert in azure portal easier. Everything else 
+can be blank. 
+
+::
+
+	openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+	-keyout managementCert.pem -out managementCert.pem 
+
+	openssl x509 -outform der -in managementCert.pem -out managementCert.cer
+
+6. You'll need a keypair to access the virtual machines during provisioning, and later via ssh. For now, 
+you should create a private key file that matches your management cert, like this:
+
+::
+
+	openssl rsa -in managementCert.pem -out managementCert.key
+
+SSH is picky about ownership/permissions on key files. Make sure that yours look like this:
+
+::
+
+	$ ls -l ~/.ssh
+	[...]
+	-rw------- 1 my_user_name my_user_name  797 May  3 18:00 managementCert.cer
+
+Use these commands if needed on the .pem, .cer, and .key files:
+
+::
+
+	# replace 'my_user_name' with your username - you knew that
+	sudo chown my_user_name:my_user_name ~/.ssh/managementCert.pem
+	sudo chmod 600 ~/.ssh/managementCert.pem
+	# make sure you do this to all 3 files!
+    
+(Note: access to a specific virtual machine using a keypair that is not also an Azure management keypair doesn't work at present, but
+is an open work item.)
+
+7. Upload managementCert.cer to your Azure subscription via the web portal (https://manage.windowsazure.com). (Scroll down to "settings" on the 
+left-hand menu, then click "management certificates" at the top, and you'll find an "upload" button at the bottom.)
+
+
+8. Edit the elasticluster config file. (The default is ``~/.elasticluster/config``. You can optionally specify a different file/path on the 
+elasticluster command line.) You can start by copying the file ``azure-sample-config`` from the same directory as this README to 
+``~/.elasticluster/config`` on your computer. You'll need to edit the items marked ``**** CHANGE ****``.
+
+For the certificate, specify the .pem file created in step 5 (e.g. ``/home/my_user_name/.ssh/managementCert.pem``).
+
+For user_key_private, specify the .key file created in step 7 (e.g. ``/home/my_user_name/.ssh/managementCert.key``). For user_key_public, specify 
+the same .pem file you used for the certificate entry.
+
+Set the basename to a meaningful string of between 3 and 15 characters, digits and lowercase letters only. All Azure resources created will 
+include this string.
+
+9. Start the cluster (``-vvv`` will produce verbose diagnostic output - you can use zero to four v's):
+
+::
+
+	elasticluster -vvv start azure-gridengine
+
+If all goes well, first you'll see global resources created and then the nodes being brought up. Then elasticluster will try to ssh to 
+each node - this typically fails for awhile, as the nodes finish booting up, and then it succeeds. When all the nodes have been contacted, the Ansible 
+provisioning step will start. This installs the normal gridengine setup that comes with elasticluster - nothing's been modified for Azure. Finally, 
+elasticluster will print a "your cluster is ready!" message.
+
+On occasion, something will go wrong during the Ansible provisioning phase, which follows the creation of the cluster itself (i.e. the 
+virtual machines, storage accounts, cloud services, and virtual network). In these cases, at the end of the output there will usually be 
+a "Your cluster is not ready!" message. If the last saved state of the cluster includes the correct addresses (ip:port) for the vms, 
+there's no need to destroy and restart from scratch. Instead, you can re-run the Ansible phase with this command:
+
+::
+
+	elasticluster -vvv setup azure-gridengine
+
+10. Contacting the cluster: this command should establish an interactive ssh connection with the head (frontend) node.
+
+::
+
+	elasticluster ssh azure-gridengine
+
+11. Other supported elasticluster commands: ``list``, ``list-nodes``, and ``list-templates``.
+
+
+12. Tearing down the cluster: this will permanently destroy all Azure resources, and stop Azure charges from accruing.
+
+::
+
+	elasticluster -vvv stop azure-gridengine
+
+13. Troubleshooting:
+
+Occasionally, Azure will start a VM, but it will stay in an unreachable state. In the Azure console, such a VM will show a status 
+of "provisioning failed". It will never respond to connection attempts. Elasticluster tries and fails to contact the VM until the 
+configured time (600 seconds, hardcoded in ``cluster.py`` as ``startup_timeout``) has elapsed. Then it will try to delete the VM (which usually 
+succeeds) and will continue on with whatever VMs 
+remain. (But if the failed node was the only frontend node, the cluster won't be much use, and you'll probably want to stop it.)
+
+If a cluster is in an unusable state, perhaps because of errors on startup or shutdown, and can't be stopped cleanly with the 
+elasticluster ``stop`` command, you might need to clean up Azure resources as well as local files to prevent errors on the next start 
+(and to prevent unwanted Azure charges). Here are the steps:
+
+1. Find your elasticluster storage directory. By default, this is ``~/.elasticluster/storage``. You might have set it to something else,  
+by using the ``-s {path}`` option on the elasticluster command line.
+
+2. From the storage directory, delete all files whose names contain your cluster name, or the base_name specified in your config. For example:
+::
+
+	rm ~/.elasticluster/storage/*azure-gridengine*
+	rm ~/.elasticluster/storage/*test1234*
+	
+3. Log into the Azure management console (https://manage.windowsazure.com) and look for resources left over from your cluster. Proceed in 
+this order:
+
+	a. Cloud services. When you delete a cloud service, choose the "delete the cloud service and its deployments" option so that the virtual
+	machines in the cloud service get deleted too.
+
+	b. Storage accounts. You might need to wait awhile after deleting a virtual machine before you can successfully delete the storage account that
+	was used to host the OS hard drive for that VM. To speed this up, go to "Virtual Machines", then "Disks", and try to delete any disks shown.
+	Once these are gone, you should be able to delete the storage account.
+
+	c. Networks. Again, it may take a few minutes after deleting other resources before you can delete a network.
+
+14. Additional config settings:
+
+The Azure provider automatically decides how many storage accounts and how many cloud services to create, based on the number of nodes being
+requested. (The constants VMS_PER_CLOUD_SERVICE and VMS_PER_STORAGE_ACCOUNT control these calculations.) However, you can override these values
+by setting n_cloud_services and/or n_storage_accounts in the [cluster] section of the config file. For clusters of 50 or more VMs, you may find
+that creating more cloud services and storage accounts improves speed of cluster starting, stopping, and usage.
+
+You can also provide the subscription_file setting, which allows you to provide more than one Azure subscription in an external file. This
+feature is experimental at this time and should not be necessary for clusters of fewer than 100 nodes.

--- a/azure-sample-config
+++ b/azure-sample-config
@@ -1,0 +1,46 @@
+# Elasticluster Azure GridEngine Example
+
+[cloud/azure-cloud]
+provider=azure
+subscription_id=****REPLACE WITH YOUR SUBSCRIPTION ID****
+certificate=****REPLACE WITH YOUR MANAGEMENT CERT****
+
+[login/azure-login]
+image_user=azureuser
+image_user_sudo=root
+image_sudo=True
+# keypair used to run stuff on the nodes.
+user_key_name=az_ec_key
+user_key_private=****REPLACE WITH PRIVATE KEY****
+user_key_public=****REPLACE WITH PUBLIC KEY****
+
+[setup/ansible-gridengine-azure]
+provider=ansible
+frontend_groups=gridengine_master
+compute_groups=gridengine_clients
+
+[cluster/azure-gridengine]
+global_var_ansible_ssh_host_key_dsa_public=''
+cloud=azure-cloud
+login=azure-login
+setup_provider=ansible-gridengine-azure
+# other locations should work
+location=East US
+# one frontend node is normal for gridengine
+frontend_nodes=1
+# change this as needed
+compute_nodes=2
+ssh_to=frontend
+# this is a very inexpensive image for testing. others should work too
+image_id=b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-12_04_2-LTS-amd64-server-20121218-en-us-30GB
+flavor=Small
+security_group=default
+# seconds allowed for all nodes to spin up:
+wait_timeout=600
+
+# azure resources will include this in their names.
+# base_name should be between 3 and 15 characters, digits and lowercase letters only.
+# note that some resources, such as storage accounts, must have names that are
+# unique across all of Azure, so set base_name accordingly.
+base_name=***REPLACE WITH BASE NAME****
+

--- a/elasticluster/__init__.py
+++ b/elasticluster/__init__.py
@@ -32,5 +32,4 @@ from elasticluster.providers.ansible_provider import AnsibleSetupProvider
 from elasticluster.providers.ec2_boto import BotoCloudProvider
 from elasticluster.providers.openstack import OpenStackCloudProvider
 from elasticluster.providers.gce import GoogleCloudProvider
-
-
+from elasticluster.providers.azure_provider import AzureCloudProvider

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -37,6 +37,7 @@ from elasticluster.exceptions import TimeoutError, NodeNotFound, \
     InstanceError, ClusterError
 from elasticluster.repository import MemRepository
 
+SSH_PORT = 22
 
 class Cluster(object):
     """This is the heart of elasticluster and handles all cluster relevant
@@ -809,11 +810,21 @@ class Node(object):
             try:
                 log.debug("Trying to connect to host %s (%s)",
                           self.name, ip)
-                ssh.connect(ip,
+                # handle case of explicit port
+                addr, _, port = ip.partition(':')
+                # if port not specified, will default to SSH_PORT (22)
+                if port:
+                    port = int(port)
+                else:
+                    addr = ip
+                    port = SSH_PORT
+
+                ssh.connect(addr,
                             username=self.image_user,
                             allow_agent=True,
                             key_filename=self.user_key_private,
-                            timeout=Node.connection_timeout)
+                            timeout=Node.connection_timeout,
+                            port=port)
                 log.debug("Connection to %s succeded!", ip)
                 if ip != self.preferred_ip:
                     log.debug("Setting `preferred_ip` to %s", ip)

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -156,6 +156,9 @@ class Configurator(object):
             elif conf['provider'] == 'google':
                 from elasticluster.providers.gce import GoogleCloudProvider
                 provider = GoogleCloudProvider
+            elif conf['provider'] == 'azure':
+                from elasticluster.providers.azure_provider import AzureCloudProvider
+                provider = AzureCloudProvider
             else:
                 raise Invalid("Invalid provider '%s' for cluster '%s'"% (conf['provider'], cluster_template))
         except ImportError, ex:
@@ -317,7 +320,7 @@ class ConfigValidator(object):
         * reading environment variables
         * interpolating configuraiton options
         """
-        # read cloud provider environment variables (ec2_boto or google, openstack)
+        # read cloud provider environment variables (ec2_boto, google, openstack, or azure)
         for cluster, props in self.config.iteritems():
             if "cloud" in props and "provider" in props['cloud']:
 
@@ -441,7 +444,10 @@ class ConfigValidator(object):
                                   Optional("region_name"): All(str, Length(min=1)),
                                   Optional("nova_api_version"): nova_api_version(),
         }
-
+        cloud_schema_azure = {"provider": 'azure',
+                              "subscription_id": All(str, Length(min=1)),
+                              "certificate": All(str, Length(min=1)),
+        }
         node_schema = {
             "flavor": All(str, Length(min=1)),
             "image_id": All(str, Length(min=1)),
@@ -455,6 +461,7 @@ class ConfigValidator(object):
         ec2_validator = Schema(cloud_schema_ec2, required=True, extra=False)
         gce_validator = Schema(cloud_schema_gce, required=True, extra=False)
         openstack_validator = Schema(cloud_schema_openstack, required=True, extra=False)
+        azure_validator = Schema(cloud_schema_azure, required=True, extra=False)
 
         if not self.config:
             raise Invalid("No clusters found in configuration.")
@@ -473,6 +480,8 @@ class ConfigValidator(object):
                     self.config[cluster]['cloud'] = gce_validator(cloud_props)
                 elif properties['cloud']['provider'] == "openstack":
                     self.config[cluster]['cloud'] = openstack_validator(cloud_props)
+                elif properties['cloud']['provider'] == "azure":
+                    self.config[cluster]['cloud'] = azure_validator(cloud_props)
             except MultipleInvalid as ex:
                 raise Invalid("Invalid configuration for cloud section `cloud/%s`: %s" % (properties['cluster']['cloud'], str.join(", ", [str(i) for i in ex.errors])))
 
@@ -551,7 +560,7 @@ class ConfigReader(object):
 
         self.schemas = {
             "cloud": Schema(
-                {"provider": Any('ec2_boto', 'google', 'openstack'),
+                {"provider": Any('ec2_boto', 'google', 'openstack', 'azure'),
                  "ec2_url": Url(str),
                  "ec2_access_key": All(str, Length(min=1)),
                  "ec2_secret_key": All(str, Length(min=1)),
@@ -565,10 +574,13 @@ class ConfigReader(object):
                  "gce_client_id": All(str, Length(min=1)),
                  "gce_client_secret": All(str, Length(min=1)),
                  "nova_client_api": nova_api_version()}, extra=True),
+                 "subscription_id": All(str, Length(min=1)),
+                 "certificate": All(str, Length(min=1)),
             "cluster": Schema(
                 {"cloud": All(str, Length(min=1)),
                  "setup_provider": All(str, Length(min=1)),
-                 "login": All(str, Length(min=1))}, required=True, extra=True),
+                 "login": All(str, Length(min=1)),
+				 "location": All(str, Length(min=1)),}, required=True, extra=True),
             "setup": Schema(
                 {"provider": All(str, Length(min=1)),
                     }, required=True, extra=True),

--- a/elasticluster/providers/azure_provider.py
+++ b/elasticluster/providers/azure_provider.py
@@ -1,0 +1,1750 @@
+#!/usr/bin/env python
+# Azure provider for elasticluster
+
+# elasticluster 'azure' package conflicts with azure SDK. This fixes
+# it by causing "import azure" to look for a system library module.
+from __future__ import absolute_import
+
+# System imports
+import os
+import pickle
+from math import floor, ceil
+import base64
+import subprocess
+import time
+import re
+import threading
+import traceback
+import random
+import xml.etree.ElementTree as xmltree
+
+# External imports
+import azure
+import azure.servicemanagement
+from azure.http import HTTPRequest
+
+# Elasticluster imports
+from elasticluster import log
+from elasticluster.providers import AbstractCloudProvider
+from elasticluster.exceptions import CloudProviderError
+
+SSH_PORT = 22
+PORT_MAP_OFFSET = 1200
+DEFAULT_WAIT_TIMEOUT = 600
+WAIT_RESULT_SLEEP = 10
+VNET_NS = 'http://schemas.microsoft.com/ServiceHosting' \
+          '/2011/07/NetworkConfiguration'
+# general-purpose retry parameters
+RETRIES = 50
+RETRY_SLEEP = 20
+RETRY_SLEEP_RND = 10
+VHD_DELETE_ATTEMPTS = 100
+VHD_DELETE_INTERVAL = 10
+
+# resource-management constants
+VMS_PER_CLOUD_SERVICE = 20
+VMS_PER_STORAGE_ACCOUNT = 40
+VMS_PER_VNET = 2000
+CLOUD_SERVICES_PER_SUBSCRIPTION = 20
+
+# helper functions
+
+
+def _retry_sleep():
+    return RETRY_SLEEP + random.randint(0, RETRY_SLEEP_RND)
+
+
+def _run_command(args):
+    proc = subprocess.Popen(
+        args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = proc.communicate()
+    return proc.returncode, stdout, stderr
+
+
+def _check_positive_integer(name, value):
+    ret = -1
+    try:
+        if '.' in value:
+            raise ValueError
+        ret = int(value)
+        if ret < 1:
+            raise ValueError
+    except Exception:
+        err = "invalid value '%s' for %s, must be integer > 0" % (
+            value, name)
+        log.error(err)
+        raise Exception(err)
+    return ret
+
+
+def ceil_div(aaa, bbb):
+    return int(ceil(float(aaa) / bbb))
+
+
+def floor_div(aaa, bbb):
+    return int(floor(float(aaa) / bbb))
+
+
+def _create_fingerprint_and_signature(cert_path):
+    rtc, stdout, stderr = _run_command(
+        ['openssl', 'x509', '-in', cert_path, '-fingerprint', '-noout'])
+    if rtc != 0:
+        err = "error getting fingerprint " \
+              "from cert %s: %s" % (cert_path, stderr)
+        log.error(err)
+        raise Exception(err)
+    fingerprint = stdout.strip()[17:].replace(':', '')
+    rtc, stdout, stderr = _run_command(
+        ['openssl', 'pkcs12', '-export', '-in', cert_path,
+         '-nokeys', '-password', 'pass:'])
+    if rtc != 0:
+        err = "error getting pkcs12 signature " \
+              "from cert_path %s: %s" % (cert_path, stderr)
+        log.error(err)
+        raise Exception(err)
+    signature = base64.b64encode(stdout.strip())
+    return fingerprint, signature
+
+
+def _create_rsa_fingerprint(key_path):
+    rtc, stdout, stderr = _run_command(
+        ['ssh-keygen', '-lf', key_path])
+    if rtc != 0:
+        err = "error getting fingerprint " \
+              "from RSA key %s: %s" % (key_path, stderr)
+        log.error(err)
+        raise Exception(err)
+    fingerprint = stdout.strip()[5:52].replace(':', '')
+    return fingerprint
+
+
+def _rest_put(subscription, path, xml):
+    # can't use SDK _perform_put because we need text/plain content-type
+    request = HTTPRequest()
+    request.method = 'PUT'
+    request.host = azure.MANAGEMENT_HOST
+    request.path = path
+    request.body = azure._get_request_body(xml)
+    request.path, request.query = azure._update_request_uri_query(request)
+    # request.headers.append(('Content-Length', str(len(request.body))))
+    request.headers.append(('Content-Type', 'text/plain'))
+    request.headers = subscription._sms._update_management_header(
+        request, azure.servicemanagement.X_MS_VERSION)
+    response = subscription._sms._perform_request(request)
+    return response
+
+
+def check_response(response):
+    if not response:
+        raise Exception("empty response")
+    if response.status != 200:
+        raise Exception("response status %s" % response.status)
+
+
+# def stats(help_string):
+#     log.debug("--->%s: %s %.3f", help_string,
+#              threading.current_thread().name, time.time())
+
+
+class AzureGlobalConfig(object):
+
+    """Manage all the settings for an Azure cluster which are
+    global as opposed to node-specific.
+
+    This does not manage resources (which are dynamic), only settings
+    (which are static, or at least are determined at cluster startup).
+    """
+
+    # we only get a few pieces of information at this point
+    def __init__(self, parent, subscription_id, certificate, storage_path):
+
+        self._parent = parent
+        # if we got a subscription here, use it. if not,
+        # a subscription_file has to be
+        # included in the cluster parameters passed to setup().
+        if subscription_id:
+            self._parent._subscriptions.append(
+                AzureSubscription(
+                    config=self,
+                    subscription_id=subscription_id,
+                    certificate=certificate, index=0))
+        self._storage_path = storage_path
+
+        self._key_name = None
+        self._public_key_path = None
+        self._private_key_path = None
+        self._location = None
+        self._base_name = None
+        self._username = None
+        self._subscription_file = None
+        self._use_public_ips = None
+        self._n_cloud_services = None
+        self._n_storage_accounts = None
+        self._n_vms_requested = None
+        self._n_subscriptions = None
+        self._cs_per_sub = None
+        self._sa_per_sub = None
+        self._security_group = None
+        self._wait_timeout = None
+        self._vm_per_cs = None
+        self._vm_per_sub = None
+        self._vm_per_sa = None
+
+    # called when the first node is about to be created. this is where
+    # we get most of the config info. this is not threadsafe - caller
+    # must ensure it isn't called concurrently and that it is only
+    # called once.
+    def setup(
+            self,
+            key_name,
+            public_key_path,
+            private_key_path,
+            security_group,
+            location,
+            base_name=None,
+            username=None,
+            subscription_file=None,
+            frontend_nodes=None,
+            compute_nodes=None,
+            use_public_ips=None,
+            wait_timeout=DEFAULT_WAIT_TIMEOUT,
+            n_cloud_services=None,
+            n_storage_accounts=None,
+            **kwargs):
+        self._key_name = key_name
+        self._public_key_path = public_key_path
+        self._private_key_path = private_key_path
+        self._security_group = security_group
+        self._location = location
+        self._base_name = base_name
+        self._username = username
+        self._subscription_file = subscription_file
+        self._wait_timeout = _check_positive_integer(
+            'wait_timeout', wait_timeout)
+
+        # elasticluster parser doesn't know about bools
+        self._use_public_ips = True if use_public_ips == 'True' else False
+
+        # subscriptions
+        self._read_subscriptions()
+
+        # resource names will be generated based on this string.
+        if len(self._base_name) < 3 or len(self._base_name) > 15:
+            err = 'base_name %s not between 3 and 15 characters' \
+                  % self._base_name
+            log.error(err)
+            raise Exception(err)
+        if re.match('[^a-z0-9]', self._base_name):
+            err = 'base_name %s is invalid, only lowercase letters and ' \
+                  'digits allowed' % self._base_name
+            log.error(err)
+            raise Exception(err)
+
+        # compute total VMs requested (warn: depends on frontend_nodes and
+        # compute_nodes being defined)
+        n_frontend_nodes = n_compute_nodes = 0
+        if frontend_nodes:
+            n_frontend_nodes = _check_positive_integer('frontend_nodes',
+                                                       frontend_nodes)
+        if compute_nodes:
+            n_compute_nodes = _check_positive_integer('compute_nodes',
+                                                      compute_nodes)
+        self._n_vms_requested = n_frontend_nodes + n_compute_nodes
+
+        # if we got resource counts, read them. otherwise compute them.
+        if n_cloud_services:
+            self._n_cloud_services = _check_positive_integer(
+                'n_cloud_services', n_cloud_services)
+        else:
+            self._n_cloud_services = ceil_div(self._n_vms_requested,
+                                              VMS_PER_CLOUD_SERVICE)
+
+        if n_storage_accounts:
+            self._n_storage_accounts = _check_positive_integer(
+                'n_storage_accounts', n_storage_accounts)
+        else:
+            self._n_storage_accounts = ceil_div(self._n_vms_requested,
+                                                VMS_PER_STORAGE_ACCOUNT)
+
+        self._n_subscriptions = len(self._parent._subscriptions)
+        if self._n_subscriptions > self._n_cloud_services or \
+                self._n_subscriptions > self._n_storage_accounts:
+            new_subs = min(self._n_cloud_services, self._n_storage_accounts)
+            msg = "Can't use all %i subscriptions available. Will only " \
+                  "use %i." % (self._n_subscriptions, new_subs)
+            log.warn(msg)
+            self._parent._subscriptions[new_subs:self._n_subscriptions] = []
+            self._n_subscriptions = new_subs
+
+        min_subscriptions = ceil_div(self._n_cloud_services,
+                                     CLOUD_SERVICES_PER_SUBSCRIPTION)
+        if self._n_subscriptions < min_subscriptions:
+            err = 'Not enough subscriptions available to meet resource' \
+                  'requirements (have %i, need %i)' % \
+                  (len(self._parent._subscriptions), min_subscriptions)
+            log.error(err)
+            raise Exception(err)
+        log.debug('compute nodes: %i. cloud services: %i. storage accounts:'
+                  ' %i. subscriptions: %i.', self._n_vms_requested,
+                  self._n_cloud_services, self._n_storage_accounts,
+                  self._n_subscriptions)
+
+        # store values needed to map vms to resources
+        self._vm_per_cs = ceil_div(
+            self._n_vms_requested, self._n_cloud_services)
+        self._cs_per_sub = ceil_div(
+            self._n_cloud_services, self._n_subscriptions)
+        self._vm_per_sub = self._vm_per_cs * self._cs_per_sub
+
+        self._vm_per_sa = ceil_div(
+            self._n_vms_requested, self._n_storage_accounts)
+        self._sa_per_sub = ceil_div(
+            self._n_storage_accounts, self._n_subscriptions)
+        if self._vm_per_sub != self._vm_per_sa * self._sa_per_sub:
+            err = 'inconsistency, %i != %i' % \
+                  (self._vm_per_sub, self._vm_per_sa * self._sa_per_sub)
+            log.error(err)
+            raise Exception(err)
+
+    # there are three ways to designate a node in the cluster:
+    # - by its flat index (0..total nodes - 1)
+    # - by its node name (we will use basename_vm%i where %i is the flat index)
+    # - by its resources - index of its subscription, its cloud service
+    #   (or alternatively its storage account), and its index within that
+    #   cloud service or storage account.
+    # We need all possible conversions amongst these.
+
+    def _vm_name_to_flat(self, vm_name):
+        if vm_name and vm_name.startswith(self._base_name + '_vm'):
+            start = len(self._base_name) + 3
+            end = start + 4
+            bare = vm_name[start:end]
+            return int(bare)
+        err = "_vm_name_to_flat: can't process vm_name %s" % vm_name
+        log.error(err)
+        raise Exception(err)
+
+    def _vm_flat_to_resources(self, vm_index):
+        i_sub = floor_div(vm_index, self._vm_per_sub)
+        i_cs = floor_div(vm_index % self._vm_per_sub, self._vm_per_cs)
+        i_vm_in_cs = vm_index - (i_sub * self._vm_per_sub) - \
+            (i_cs * self._vm_per_cs)
+        i_sa = floor_div(vm_index % self._vm_per_sub, self._vm_per_sa)
+        i_vm_in_sa = vm_index - (i_sub * self._vm_per_sub) - \
+            (i_sa * self._vm_per_sa)
+        return i_sub, i_cs, i_vm_in_cs, i_sa, i_vm_in_sa
+
+    def _vm_name_to_resources(self, vm_name):
+        return self._vm_flat_to_resources(self._vm_name_to_flat(vm_name))
+
+    def _read_subscriptions(self):
+        ids = set()
+        if self._subscription_file:
+            if self._parent._subscriptions:
+                log.debug(
+                    'subscription was passed in cloud section, and '
+                    'subscription_file was '
+                    'also passed in cluster section. using both.')
+                ids.add(self._parent._subscriptions[0]._subscription_id)
+            try:
+                pattern = re.compile(
+                    r'subscription_id=(\S*)\s+certificate=(.*)')
+                with open(self._subscription_file) as fhl:
+                    for line in fhl:
+                        match = pattern.match(line)
+                        if match:
+                            if match.group(1) in ids:
+                                log.debug('subscription_id %s has already been'
+                                          ' read. ignoring.', match.group(1))
+                            else:
+                                ids.add(match.group(1))
+                                index = len(self._parent._subscriptions)
+                                self._parent._subscriptions.append(
+                                    AzureSubscription(
+                                        config=self,
+                                        subscription_id=match.group(1),
+                                        certificate=os.path.expanduser(
+                                            match.group(2)),
+                                        index=index))
+                        else:
+                            log.debug(
+                                'ignoring line in subscription_file %s: %s',
+                                self._subscription_file, line)
+            except Exception as exc:
+                log.error('error parsing subscription file %s: %s',
+                          self._subscription_file, exc)
+
+
+class AzureSubscription(object):
+
+    def __init__(self, config, subscription_id, certificate, index):
+        self._do_cleanup = False    # never delete a subscription
+        self._config = config
+        self._subscription_id = subscription_id
+        self._certificate = certificate
+        self._index = index
+        self._sms_internal = None
+        self._resource_lock_internal = None
+        self._storage_accounts = list()
+        self._cloud_services = list()
+        self._vnet = None
+
+        # create fingerprint and signature from subscription cert, to
+        # be added to cloud services/vms
+        fingerprint, signature = _create_fingerprint_and_signature(
+            self._certificate)
+        self._fingerprint = fingerprint
+        self._pkcs12_base64 = signature
+
+        # initialize properties
+        _ = self._resource_lock  # force instantiation
+        if self._sms_internal is None:
+            try:
+                self._sms_internal = \
+                    azure.servicemanagement.ServiceManagementService(
+                        self._subscription_id, self._certificate)
+            except Exception as exc:
+                log.error('error initializing azure serice: %s', exc)
+                raise
+
+    @property
+    def _resource_lock(self):
+        if self._resource_lock_internal is None:
+            self._resource_lock_internal = threading.RLock()
+        return self._resource_lock_internal
+
+    @property
+    def _sms(self):
+        if self._sms_internal is None:
+            try:
+                self._sms_internal = \
+                    azure.servicemanagement.ServiceManagementService(
+                        self._subscription_id, self._certificate)
+            except Exception as exc:
+                log.error('error initializing azure serice: %s', exc)
+                raise
+        return self._sms_internal
+
+    @property
+    def _n_instances(self):
+        ret = 0
+        with self._resource_lock:
+            for cloud_service in self._cloud_services:
+                ret = ret + cloud_service._n_instances
+            return ret
+
+    # this needs to be in here because sms is per-subscription
+    def _wait_result(self, req, timeout=None):
+        if not timeout:
+            timeout = self._config._wait_timeout
+        if not req:
+            return  # sometimes this happens, seems to mean success
+        giveup_time = time.time() + timeout
+        while giveup_time > time.time():
+            operation_result = self._sms.get_operation_status(req.request_id)
+            if operation_result.status == "InProgress":
+                time.sleep(WAIT_RESULT_SLEEP)
+                continue
+            if operation_result.status == "Succeeded":
+                return
+            if operation_result.status == "Failed":
+                err = 'async operation failed: %s' \
+                      % operation_result.error.message
+                log.error(err)
+                raise CloudProviderError(err)
+        err = 'async operation timed out'
+        log.error(err)
+        raise CloudProviderError(err)
+
+    def __getstate__(self):
+        dct = self.__dict__.copy()
+        del dct['_resource_lock_internal']
+        del dct['_sms_internal']
+        return dct
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self._resource_lock_internal = None
+        self._sms_internal = None
+
+    def _find_os_disks(self):
+        # associate disk names of os vhd's with their nodes.
+        try:
+            disks = self._sms.list_disks()
+            for disk in disks:
+                for cloud_service in self._cloud_services:
+                    for vm_name, v_m in cloud_service._instances.iteritems():
+                        if v_m._os_vhd_name:
+                            continue
+                        if vm_name in disk.name and \
+                                self._config._base_name in disk.name:
+                            v_m._os_vhd_name = disk.name
+        except Exception as exc:
+            log.error('error in _find_os_disks: %s', exc)
+            raise
+
+
+class AzureCloudService(object):
+
+    def __init__(self, config, subscription, index):
+        self._do_cleanup = False
+        self._config = config
+        self._subscription = subscription
+        self._location = config._location
+        self._index = index
+        self._name = "%ssu%ics%i" % (
+            self._config._base_name, self._subscription._index, self._index)
+        # treat deployment as sub-item of cloud service
+        # deployment has same name as cloud service
+        # only instances owned by this cloud service:
+        self._instances = {}
+        self._resource_lock_internal = None
+        self._deployment_created = False
+
+    @property
+    def _resource_lock(self):
+        if self._resource_lock_internal is None:
+            self._resource_lock_internal = threading.RLock()
+        return self._resource_lock_internal
+
+    @property
+    def _n_instances(self):
+        with self._resource_lock:
+            return len(self._instances)
+
+    @property
+    def _exists(self):
+        try:
+            self._subscription._sms.get_hosted_service_properties(
+                service_name=self._name)
+            log.debug("cloud service %s exists", self._name)
+            return True
+        except Exception as exc:
+            if str(exc) != 'Not found (Not Found)':
+                log.error('error checking for cloud service %s: %s',
+                          self._name, str(exc))
+                raise
+        return False
+
+    def _create(self):
+        with self._resource_lock:
+            if not self._exists:
+                try:
+                    result = self._subscription._sms.create_hosted_service(
+                        service_name=self._name,
+                        label=self._name,
+                        location=self._location)
+                    self._subscription._wait_result(result)
+                except Exception as exc:
+                    # this shouldn't happen
+                    # if str(e) == 'Conflict (Conflict)':
+                    #    return False
+                    log.error('error creating cloud service %s: %s',
+                              self._name, exc)
+                    raise
+
+    def _delete(self):
+        with self._resource_lock:
+            if self._deployment:
+                log.error("can't delete cloud service %s. It contains a "
+                          "deployment and at least one node.", self._name)
+                return False
+            try:
+                self._subscription._sms.delete_hosted_service(
+                    service_name=self._name)
+            except Exception as exc:
+                log.error('error deleting cloud service %s: %s',
+                          self._name, exc)
+                raise
+            return True
+
+    # called by _stop_vm when vm is the last node in the deployment.
+    def _delete_deployment(self):
+        try:
+            result = self._subscription._sms.delete_deployment(
+                service_name=self._name,
+                deployment_name=self._name)
+            self._subscription._wait_result(result)
+        except Exception as exc:
+            log.error('error deleting deployment from cloud service %s: %s',
+                      self._name, exc)
+            raise
+
+    @property
+    def _deployment(self):
+        try:
+            dep = self._subscription._sms.get_deployment_by_name(
+                service_name=self._name, deployment_name=self._name)
+            return dep
+        except Exception as exc:
+            if str(exc) == 'Not found (Not Found)':
+                return None
+            log.error('error getting deployment %s: %s', self._name, exc)
+            raise
+
+    def _add_certificate(self):
+        # Add certificate to cloud service
+        result = self._subscription._sms.add_service_certificate(
+            self._name, self._subscription._pkcs12_base64, 'pfx', '')
+        self._subscription._wait_result(result)
+
+    def _start_vm(self, v_m):
+        with self._resource_lock:
+            if not self._deployment_created:
+                # block while we create the deployment and start the vm
+                attempt = 1
+                sub = self._subscription
+                sms = sub._sms
+                while attempt < RETRIES:
+                    try:
+                        result = sms.create_virtual_machine_deployment(
+                            service_name=self._name,
+                            deployment_name=self._name,
+                            deployment_slot='production',
+                            label=v_m._node_name,
+                            role_name=v_m._qualified_name,
+                            system_config=v_m._system_config,
+                            network_config=v_m._network_config,
+                            os_virtual_hard_disk=v_m._os_virtual_hard_disk,
+                            role_size=v_m._flavor,
+                            role_type='PersistentVMRole',
+                            virtual_network_name=v_m._virtual_network_name)
+                        sub._wait_result(result)
+                        break
+                    except Exception as exc:
+                        if str(exc) == 'Conflict (Conflict)':
+                            log.error('error creating vm %s (attempt %i of '
+                                      '%i): virtual machine already exists.',
+                                      v_m._qualified_name, attempt, RETRIES)
+                            raise   # this is serialized, so probably a
+                            # legit error
+                        if 'is invalid' in str(exc):
+                            if re.match('value .* for parameter .* '
+                                        'is invalid', str(exc)):
+                                log.error('error creating vm %s (attempt %i '
+                                          'of %i): virtual machine '
+                                          'already exists.',
+                                          v_m._qualified_name, attempt,
+                                          RETRIES)
+                                raise   # treat as legit error
+                        else:
+                            log.error('error creating vm %s (attempt '
+                                      '%i of %i): %s', v_m._qualified_name,
+                                      attempt, RETRIES, exc)
+                    time.sleep(_retry_sleep())
+                    attempt += 1
+                if attempt >= RETRIES:
+                    err = 'AzureVM start %s: giving up after %i attempts' % \
+                          (v_m._qualified_name, RETRIES)
+                    log.error(err)
+                    raise Exception(err)
+
+                # need to find the disk name for the OS disk attached to
+                # this vm.
+                self._subscription._find_os_disks()
+                v_m._created = True
+                self._deployment_created = True
+                return
+
+        # add the vm to the deployment - can be parallel (?)
+        attempt = 1
+        sub = self._subscription
+        sms = sub._sms
+        while attempt < RETRIES:
+            try:
+                log.debug("attempt %i to start vm node name %s qual name %s",
+                          attempt, v_m._node_name, v_m._qualified_name)
+                result = sms.add_role(
+                    service_name=self._name,
+                    deployment_name=self._name,
+                    role_name=v_m._qualified_name,
+                    system_config=v_m._system_config,
+                    network_config=v_m._network_config,
+                    os_virtual_hard_disk=v_m._os_virtual_hard_disk,
+                    role_size=v_m._flavor,
+                    role_type='PersistentVMRole')
+                sub._wait_result(result)
+                break
+            except azure.WindowsAzureConflictError as exc:
+                log.error('WindowsAzureConflictError creating vm %s (attempt '
+                          '%i of %i): %s', v_m._qualified_name,
+                          attempt, RETRIES, exc)
+            except Exception as exc:
+                log.error('error creating vm %s (attempt '
+                          '%i of %i): %s', v_m._qualified_name,
+                          attempt, RETRIES, exc)
+            time.sleep(_retry_sleep())
+            attempt += 1
+        if attempt >= RETRIES:
+            err = 'AzureVM start %s: giving up after %i attempts' % \
+                  (v_m._qualified_name, RETRIES)
+            log.error(err)
+            raise Exception(err)
+        # need to find the disk name for the OS disk attached to
+        # this vm.
+        self._subscription._find_os_disks()
+        v_m._created = True
+
+    def _stop_vm(self, v_m):
+        attempt = 1
+        sub = self._subscription
+        sms = sub._sms
+        while attempt < RETRIES:
+            try:
+                log.debug("attempt %i to stop vm node name %s qual name %s",
+                          attempt, v_m._node_name, v_m._qualified_name)
+                if len(self._instances) == 1:
+                    # we are the last node in this cloud service,
+                    # so delete deployment
+                    self._delete_deployment()
+                else:
+                    result = sms.delete_role(
+                        service_name=self._name,
+                        deployment_name=self._name,
+                        role_name=v_m._qualified_name)
+                    sub._wait_result(result)
+
+                with self._resource_lock:
+                    prov = self._config._parent
+                    prov._disks_to_delete[v_m._os_vhd_name] = {
+                        'SMS': v_m._subscription._sms,
+                        'TRIES': 0, 'LATEST_TRY': None}
+                    del self._instances[v_m._qualified_name]
+                break
+            except Exception as exc:
+                log.error('error stopping vm %s (attempt '
+                          '%i of %i): %s', v_m._qualified_name,
+                          attempt, RETRIES, exc)
+                if str(exc) == 'Not found (Not Found)':
+                    # assume the error is right, and try to clean up the
+                    # leftovers of the vm state
+                    with self._resource_lock:
+                        prov = self._config._parent
+                        prov._disks_to_delete[v_m._os_vhd_name] = {
+                            'SMS': v_m._subscription._sms,
+                            'TRIES': 0, 'LATEST_TRY': None}
+                        del self._instances[v_m._qualified_name]
+                    break
+            time.sleep(_retry_sleep())
+            attempt += 1
+        if attempt >= RETRIES:
+            err = '_stop_vm %s: giving up after %i attempts' % \
+                  (v_m._qualified_name, RETRIES)
+            log.error(err)
+            raise Exception(err)
+
+    def __getstate__(self):
+        dct = self.__dict__.copy()
+        del dct['_resource_lock_internal']
+        return dct
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self._resource_lock_internal = None
+
+
+class AzureStorageAccount(object):
+
+    def __init__(self, config, subscription, index):
+        self._do_cleanup = False
+        self._created = False
+        self._config = config
+        self._subscription = subscription
+        self._index = index
+        self._name = "%ssu%ist%i" % (
+            self._config._base_name, self._subscription._index, self._index)
+        self._resource_lock_internal = None
+
+    @property
+    def _resource_lock(self):
+        if self._resource_lock_internal is None:
+            self._resource_lock_internal = threading.Lock()
+        return self._resource_lock_internal
+
+    def _exists(self):
+        try:
+            self._subscription._sms.get_storage_account_properties(
+                service_name=self._name)
+            # note - this will only find a storage account of the given name
+            # within this subscription. Doesn't guarantee the name isn't in
+            # use anywhere in Azure, so be cautious with the result from
+            # this method.
+            log.debug("storage account %s exists", self._name)
+            return True
+        except Exception as exc:
+            if str(exc) != 'Not found (Not Found)':
+                log.error('error checking for storage account %s: %s',
+                          self._name, str(exc))
+                raise
+            return False
+
+    def _create(self):
+        if not self._exists():
+            try:
+                result = self._subscription._sms.create_storage_account(
+                    service_name=self._name,
+                    description=self._name,
+                    label=self._name,
+                    location=self._config._location,
+                    account_type='Standard_LRS'
+                )
+                # this seems to be taking much longer than the others...
+                self._subscription._wait_result(
+                    result, self._config._wait_timeout * 10)
+            except Exception as exc:
+                # this probably means that there is a storage account with
+                # the requested name in Azure, but not in this subscription.
+                if str(exc) == 'Conflict (Conflict)':
+                    log.error("Storage account %s already exists in Azure (may"
+                              " be in some other subscription)", self._name)
+                log.error('error creating storage account %s: %s',
+                          self._name, str(exc))
+                raise
+
+    def _delete(self):
+        attempts = 10
+        for attempt in range(1, attempts):
+            try:
+                self._subscription._sms.delete_storage_account(
+                    service_name=self._name)
+                log.debug('delete storage account %s: success on attempt %i',
+                          self._name, attempt)
+                return
+            except Exception as exc:
+                log.error('delete storage account %s: error on attempt '
+                          '#%i: %s', self._name, attempt, exc)
+                time.sleep(10)
+        err = 'delete storage account %s: giving up after %i attempts' % \
+              (self._name, attempts)
+        log.error(err)
+        raise Exception(err)
+
+    def _create_vhd(self, node_name, image_id):
+        disk_url = u'http://%s.blob.core.windows.net/vhds/%s.vhd' % (
+            self._name, node_name)
+        vhd = azure.servicemanagement.OSVirtualHardDisk(image_id, disk_url)
+        return vhd, disk_url
+
+    def __getstate__(self):
+        dct = self.__dict__.copy()
+        del dct['_resource_lock_internal']
+        return dct
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self._resource_lock_internal = None
+
+
+class AzureVNet(object):
+
+    def __init__(self, config, subscription, index):
+        self._do_cleanup = False
+        self._config = config
+        self._subscription = subscription
+        self._index = index
+        self._name = "%ssu%ivn%i" % (
+            self._config._base_name, self._subscription._index, self._index)
+        self._resource_lock_internal = None
+        # location comes from config
+
+    @property
+    def _resource_lock(self):
+        if self._resource_lock_internal is None:
+            self._resource_lock_internal = threading.Lock()
+        return self._resource_lock_internal
+
+    def _exists(self):
+        try:
+            result = self._subscription._sms.list_virtual_network_sites()
+            if len(result):
+                for virtual_network_site in result.virtual_network_sites:
+                    if virtual_network_site.name == self._name:
+                        log.debug("vnet %s exists", self._name)
+                        return True
+                return False
+            else:
+                return False    # no vnets
+        except Exception as exc:
+            log.error('error checking existence of vnet %s: %s',
+                      self._name, exc)
+            raise
+
+    @property
+    def _path(self):
+        return "/%s/services/networking/media" % \
+               self._subscription._subscription_id
+
+    def _get_xml(self):
+        # get the xml defining the current vnet config for the whole
+        # subscription.
+        attempt = 1
+        while attempt < RETRIES:
+            try:
+                response = self._subscription._sms.perform_get(self._path)
+                check_response(response)
+                return response.body
+            except Exception as exc:
+                if str(exc) == 'Not found (Not Found)':
+                    return None
+                log.error('error in _get_xml for vnet %s '
+                          '(attempt %i of %i): %s',
+                          self._name, attempt, RETRIES, exc)
+            time.sleep(_retry_sleep())
+            attempt += 1
+        err = "AzureVNet %s _get_xml: giving up after %i attempts" % \
+              (self._name, RETRIES)
+        log.error(err)
+        raise Exception(err)
+
+    def _create(self):
+        if self._exists():
+            return
+        tree = None
+        xml = None
+        self._register_namespaces()
+        try:
+            # since we will be rewriting the whole network config, first
+            # we need to get the xml for any existing vnets, and if
+            # there is any, fold ours in.
+            prior_xml = self._get_xml()
+            if prior_xml:
+                # vnets already defined (possibly including ours, although
+                # it shouldn't be - we already checked)
+                # search for ours
+                tree = xmltree.fromstring(prior_xml)
+                config = tree.find(
+                    self._deco('VirtualNetworkConfiguration'))
+                sites = config.find(self._deco('VirtualNetworkSites'))
+                if sites is not None:  # plain "if sites" gets a warning
+                    for site in sites.findall(
+                            self._deco('VirtualNetworkSite')):
+                        if site.get('name') == self._name:
+                            if site.get('location') == self._config._location:
+                                log.warn("unexpected: found in xml: vnet %s with "
+                                         "location %s",
+                                         self._name, self._config._location)
+                            else:
+                                log.warn("vnet %s found in xml, but location "
+                                         "is %s (expected %s)", self._name,
+                                         site.get('location'),
+                                         self._config._location)
+                            return
+                else:
+                    # probably means there is 1+ DNS servers but no vnets
+                    sites = xmltree.Element(self._deco('VirtualNetworkSites'))
+                    config.append(sites)
+            else:
+                # no vnets defined. just add ours
+                prior_xml = self._empty_network_config_xml()
+                tree = xmltree.fromstring(prior_xml)
+                config = tree.find(
+                    self._deco('VirtualNetworkConfiguration'))
+                sites = config.find(self._deco('VirtualNetworkSites'))
+
+            subtree = self._make_vnet_subtree()
+            sites.append(subtree)
+            xml = xmltree.tostring(tree)
+        except Exception as exc:
+            err = 'error preparing AzureVNet _create: %s' % exc
+            log.error(err)
+            raise
+        # replace the whole network config,
+        attempt = 1
+        while attempt < RETRIES:
+            try:
+                response = _rest_put(self._subscription, self._path, xml)
+                result = azure.servicemanagement.AsynchronousOperationResult()
+                if response.headers:
+                    for name, value in response.headers:
+                        if name.lower() == 'x-ms-request-id':
+                            result.request_id = value
+                            break
+                self._subscription._wait_result(
+                    result, self._config._wait_timeout)
+                log.debug('created vnet %s', self._name)
+                return
+            except Exception as exc:
+                if 'validation error' in str(exc):
+                    err = 'fatal error in _create for vnet %s: %s' \
+                          % (self._name, exc)
+                    log.error(err)
+                    raise  # no point retrying
+                log.error('error in _create for vnet %s '
+                          '(attempt %i of %i): %s',
+                          self._name, attempt, RETRIES, exc)
+            time.sleep(_retry_sleep())
+            attempt += 1
+        err = "AzureVNet %s _delete: giving up after %i attempts" % \
+              (self._name, RETRIES)
+        log.error(err)
+        raise Exception(err)
+
+    def _delete(self):
+        if not self._exists():
+            return
+        tree = None
+        xml = None
+        self._register_namespaces()
+        found = None
+        try:
+            prior_xml = self._get_xml()  # should exist
+            # search for ours
+            tree = xmltree.fromstring(prior_xml)
+            config = tree.find(
+                self._deco('VirtualNetworkConfiguration'))
+            sites = config.find(self._deco('VirtualNetworkSites'))
+            if sites is not None:
+                for site in sites.findall(self._deco('VirtualNetworkSite')):
+                    if site.get('name') == self._name:
+                        if site.get('Location') != self._config._location:
+                            log.warn("vnet %s found in xml, but location is %s "
+                                     "(expected %s)", self._name,
+                                     site.get('location'), self._config._location)
+                        sites.remove(site)
+                        found = True
+                        break
+                if not found:
+                    raise Exception("AzureVNet _delete: vnet %s exists, but "
+                                    "not found in xml" % self._name)
+            xml = xmltree.tostring(tree)
+        except Exception as exc:
+            err = 'error preparing AzureVNet _delete: %s' % exc
+            log.error(err)
+            raise
+        # replace the whole network config,
+        attempt = 1
+        while attempt < RETRIES:
+            try:
+                response = _rest_put(self._subscription, self._path, xml)
+                result = azure.servicemanagement.AsynchronousOperationResult()
+                if response.headers:
+                    for name, value in response.headers:
+                        if name.lower() == 'x-ms-request-id':
+                            result.request_id = value
+                self._subscription._wait_result(
+                    result, self._config._wait_timeout)
+                log.debug('deleted vnet %s', self._name)
+                return
+            except Exception as exc:
+                log.error('error in _delete for vnet %s '
+                          '(attempt %i of %i): %s',
+                          self._name, attempt, RETRIES, exc)
+            time.sleep(_retry_sleep())
+            attempt += 1
+        err = "AzureVNet %s _delete: giving up after %i attempts" % \
+              (self._name, RETRIES)
+        log.error(err)
+        raise Exception(err)
+
+    @staticmethod
+    def _register_namespaces():
+        xmltree.register_namespace('', 'http://www.w3.org/2001/XMLSchema')
+        xmltree.register_namespace(
+            '', 'http://www.w3.org/2001/XMLSchema-instance')
+        xmltree.register_namespace('', VNET_NS)
+
+    @staticmethod
+    def _deco(strng):
+        return '{%s}%s' % (VNET_NS, strng)
+
+    # create a network config with no vnets
+    @staticmethod
+    def _empty_network_config_xml():
+        template = "<NetworkConfiguration xmlns:xsd=\"http://www.w3.org/" \
+                   "2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/" \
+                   "XMLSchema-instance\" xmlns=\"http://schemas." \
+                   "microsoft.com/ServiceHosting/2011/07/" \
+                   "NetworkConfiguration\">"
+        template = template + """
+  <VirtualNetworkConfiguration>
+    <Dns>
+      <DnsServers>
+      </DnsServers>
+    </Dns>
+    <VirtualNetworkSites>
+    </VirtualNetworkSites>
+  </VirtualNetworkConfiguration>
+</NetworkConfiguration>"""
+        return template
+
+    # create xml subtree for a vnet with our name and location
+    def _make_vnet_subtree(self):
+        subtree = xmltree.Element(self._deco('VirtualNetworkSite'))
+        subtree.set('name', self._name)
+        subtree.set('Location', self._config._location)
+        addrspace = xmltree.SubElement(subtree, self._deco('AddressSpace'))
+        prefix = xmltree.SubElement(addrspace, self._deco('AddressPrefix'))
+        prefix.text = '10.0.0.0/8'
+        subnets = xmltree.SubElement(subtree, self._deco('Subnets'))
+        subnet = xmltree.SubElement(subnets, self._deco('Subnet'))
+        subnet.set('name', 'subnet1')
+        subprefix = xmltree.SubElement(subnet, self._deco('AddressPrefix'))
+        subprefix.text = '10.0.0.0/11'
+        return subtree
+
+    # return info on all vnets currently defined in a subscription
+    @staticmethod
+    def _get_list(subscription, strng):
+        try:
+            ret = list()
+            result = subscription._sms.list_virtual_network_sites()
+            if len(result):
+                for virtual_network_site in result.virtual_network_sites:
+                    ret.append(virtual_network_site.name)
+            return ret
+        except Exception as exc:
+            log.error('error getting list of vnets for subscription %s: %s',
+                      subscription._name, exc)
+            raise
+
+    def __getstate__(self):
+        dct = self.__dict__.copy()
+        del dct['_resource_lock_internal']
+        return dct
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self._resource_lock_internal = None
+
+
+class AzureVM(object):
+
+    def __init__(
+            self,
+            config,
+            node_index,
+            cloud_service=None,
+            storage_account=None,
+            subscription=None,
+            flavor=None,
+            image=None,
+            node_name=None,
+            host_name=None,
+            image_userdata=None):
+        self._do_cleanup = False
+        self._config = config
+        self._node_index = node_index
+        self._cloud_service = cloud_service
+        self._storage_account = storage_account
+        self._subscription = subscription
+        self._flavor = flavor
+        self._image = image
+        self._node_name = node_name
+        self._host_name = host_name
+        self._image_userdata = image_userdata
+
+        # figure out what sub, cloud serv, stor acct to use if not specified
+        if not self._cloud_service:
+            parent = self._config._parent
+            (i_subscription, i_cloud_service, _, i_storage_account, _) = \
+                self._config._vm_flat_to_resources(self._node_index)
+            self._subscription = parent._subscriptions[i_subscription]
+            self._cloud_service = \
+                self._subscription._cloud_services[i_cloud_service]
+            self._storage_account = \
+                self._subscription._storage_accounts[i_storage_account]
+
+        self._qualified_name = '{0}_vm{1:04d}_{2}'.format(
+            self._config._base_name, self._node_index, self._node_name)
+        self._public_ip_internal = None
+        self._ssh_port = None
+        self._os_virtual_hard_disk = None
+        self._os_vhd_name = None
+        self._created = False
+        self._paused = False
+        self._system_config = None
+        self._network_config = None
+        self._virtual_network_name = None
+
+        try:
+            self._create_network_config()
+
+            (self._os_virtual_hard_disk, _) = \
+                self._storage_account._create_vhd(self._node_name, self._image)
+            self._virtual_network_name = \
+                self._subscription._vnet._name
+        except Exception as exc:
+            log.error('error creating reqs for vm %s: %s',
+                      self._qualified_name, exc)
+            raise
+
+    def pause(self, instance_id, keep_provisioned=True):
+        """shuts down the instance without destroying it.
+
+        The AbstractCloudProvider class uses 'stop' to refer to destroying
+        a VM, so use 'pause' to mean powering it down while leaving it
+        allocated.
+
+        :param str instance_id: instance identifier
+
+        :return: None
+        """
+        try:
+            if self._paused:
+                log.debug("node %s is already paused", instance_id)
+                return
+            self._paused = True
+            post_shutdown_action = 'Stopped' if keep_provisioned else \
+                'StoppedDeallocated'
+            result = self._subscription._sms.shutdown_role(
+                service_name=self._cloud_service._name,
+                deployment_name=self._cloud_service._name,
+                role_name=self._qualified_name,
+                post_shutdown_action=post_shutdown_action)
+            self._subscription._wait_result(result)
+        except Exception as exc:
+            log.error("error pausing instance %s: %s", instance_id, exc)
+            raise
+        log.debug('paused instance(instance_id=%s)', instance_id)
+
+    def restart(self, instance_id):
+        """restarts a paused instance.
+
+        :param str instance_id: instance identifier
+
+        :return: None
+        """
+        try:
+            if not self._paused:
+                log.debug("node %s is not paused, can't restart", instance_id)
+                return
+            self._paused = False
+            result = self._subscription._sms.start_role(
+                service_name=self._cloud_service._name,
+                deployment_name=self._cloud_service._name,
+                role_name=instance_id)
+            self._subscription._wait_result(result)
+        except Exception as exc:
+            log.error('error restarting instance %s: %s', instance_id, exc)
+            raise
+        log.debug('restarted instance(instance_id=%s)', instance_id)
+
+    def _create_network_config(self):
+        # Create linux configuration
+        self._system_config = azure.servicemanagement.LinuxConfigurationSet(
+            self._node_name,
+            self._config._username,
+            None,
+            disable_ssh_password_authentication=True)
+        ssh_config = azure.servicemanagement.SSH()
+        ssh_config.public_keys = azure.servicemanagement.PublicKeys()
+        authorized_keys_path = u'/home/%s/.ssh/authorized_keys' \
+                               % self._config._username
+        ssh_config.public_keys.public_keys.append(
+            azure.servicemanagement.PublicKey(
+                path=authorized_keys_path,
+                fingerprint=self._subscription._fingerprint))
+        self._system_config.ssh = ssh_config
+
+        # Create network configuration
+        self._network_config = azure.servicemanagement.ConfigurationSet()
+        self._network_config.configuration_set_type = 'NetworkConfiguration'
+        if self._config._use_public_ips:
+            public_ip = azure.servicemanagement.PublicIP(
+                u'pip-%s' % self._node_name)
+            # allowed range is 4-30 mins
+            public_ip.idle_timeout_in_minutes = 30
+            public_ips = azure.servicemanagement.PublicIPs()
+            public_ips.public_ips.append(public_ip)
+            self._network_config.public_ips = public_ips
+            self._ssh_port = SSH_PORT
+        else:
+            # create endpoints for ssh (22). Map to an offset + instance
+            # index + port # for the public side
+            self._ssh_port = PORT_MAP_OFFSET + self._node_index + SSH_PORT
+
+        endpoints = azure.servicemanagement.ConfigurationSetInputEndpoints()
+        endpoints.subnet_names = []
+        endpoints.input_endpoints.append(
+            azure.servicemanagement.ConfigurationSetInputEndpoint(
+                name='TCP-%s' %
+                self._ssh_port,
+                protocol='TCP',
+                port=self._ssh_port,
+                local_port=SSH_PORT))
+        self._network_config.input_endpoints = endpoints
+
+    @property
+    def _power_state(self):
+        instances = self._cloud_service._deployment.role_instance_list
+        for instance in instances:
+            if instance.instance_name == self._qualified_name:
+                # cache IP since it will be asked for soon
+                if self._config._use_public_ips:
+                    self._public_ip_internal = instance.public_ips[0].address
+                else:
+                    self._public_ip_internal = instance.instance_endpoints[
+                        0].vip
+                return instance.power_state
+        raise Exception("could not get power_state for instance %s"
+                        % self._qualified_name)
+
+    @property
+    def _public_ip(self):
+        if not self._public_ip_internal:
+            # not cached, so look it up
+            instances = self._cloud_service._deployment.role_instance_list
+            for instance in instances:
+                if instance.instance_name == self._qualified_name:
+                    if self._config._use_public_ips:
+                        self._public_ip_internal = instance.public_ips[
+                            0].address
+                    else:
+                        self._public_ip_internal = instance.instance_endpoints[
+                            0].vip
+                    return instance.power_state
+            raise Exception("could not get public IP for instance %s"
+                            % self._qualified_name)
+        return self._public_ip_internal
+
+
+class AzureCloudProvider(AbstractCloudProvider):
+
+    """This implementation of
+    :py:class:`elasticluster.providers.AbstractCloudProvider` uses the
+    Azure Python interface connect to the Azure clouds and manage instances.
+
+    An AzureCloudProvider owns a tree of Azure resources, rooted in one or
+    more subscriptions and one or more storage accounts.
+    """
+
+    def __init__(self,
+                 subscription_id,
+                 certificate,
+                 storage_path=None):
+        """The constructor of AzureCloudProvider class is called only
+        using keyword arguments.
+
+        Usually these are configuration option of the corresponding
+        `setup` section in the configuration file.
+        """
+        # Paramiko debug level
+        # import logging
+        # logging.getLogger('paramiko').setLevel(logging.DEBUG)
+        # logging.basicConfig(level=logging.DEBUG)
+
+        # Ansible debug level
+        # import ansible
+        # import ansible.utils
+        # ansible.utils.VERBOSITY = 9
+
+        # auto stack tracing
+        # import stacktracer
+        # stacktracer.trace_start("trace.html",interval=15,auto=True)
+
+        # flag indicating resource creation failed - don't even
+        # attempt node operations after this is set
+        self._start_failed = None
+
+        # this lock should never be held for long - only for changes to the
+        # resource arrays this object owns, and queries about same.
+        self._resource_lock_internal = None
+
+        # resources
+        self._cluster_prep_done = False
+        self._subscriptions = []
+
+        # diagnostics
+        self._times = {}
+
+        # cleanup
+        self._disks_to_delete = {}
+
+        self._config = AzureGlobalConfig(
+            self, subscription_id, os.path.expanduser(certificate),
+            storage_path)
+
+    def start_instance(
+            self,
+            key_name,
+            public_key_path,
+            private_key_path,
+            security_group,
+            flavor,
+            image,
+            image_userdata,
+            location=None,
+            base_name=None,
+            username=None,
+            node_name=None,
+            host_name=None,
+            use_public_ips=None,
+            wait_timeout=None,
+            use_short_vm_names=None,
+            n_cloud_services=None,
+            n_storage_accounts=None,
+            **kwargs):
+        """Starts a new instance on the cloud using the given properties.
+        Multiple instances might be started in different threads at the same
+        time. The implementation should handle any problems regarding this
+        itself.
+        :return: str - instance id of the started instance
+        """
+
+        if self._start_failed:
+            raise Exception('start_instance for node %s: failing due to'
+                            ' previous errors.' % node_name)
+
+        index = None
+        with self._resource_lock:
+            # it'd be nice if elasticluster called something like
+            # init_cluster() with all the args that will be the
+            # same for every node created. But since it doesn't, handle that on
+            # first start_instance call.
+            if not self._cluster_prep_done:
+                self._times['CLUSTER_START'] = time.time()
+                self._config.setup(
+                    key_name,
+                    public_key_path,
+                    private_key_path,
+                    security_group,
+                    location,
+                    base_name=base_name,
+                    username=username,
+                    use_public_ips=use_public_ips,
+                    wait_timeout=wait_timeout,
+                    use_short_vm_names=use_short_vm_names,
+                    n_cloud_services=n_cloud_services,
+                    n_storage_accounts=n_storage_accounts,
+                    **kwargs)
+                # we know we're starting the first node, so create global
+                # requirements now
+                self._create_global_reqs()
+                if self._start_failed:
+                    return None
+                # this will allow vms to be created
+                self._times['SETUP_DONE'] = time.time()
+                self._cluster_prep_done = True
+
+            # absolute node index in cluster (0..n-1) determines what
+            # subscription, cloud service, storage
+            # account, etc. this VM will use. Create the vm and add it to
+            # its cloud service, then try to start it.
+            index = self._n_instances
+
+            v_m = AzureVM(
+                self._config,
+                index,
+                flavor=flavor,
+                image=image,
+                node_name=node_name,
+                host_name=host_name,
+                image_userdata=image_userdata)
+            v_m._cloud_service._instances[v_m._qualified_name] = v_m
+
+        try:
+            v_m._cloud_service._start_vm(v_m)
+        except Exception:
+            log.error(traceback.format_exc())
+            log.error("setting start_failed flag. Will not "
+                      "try to start further nodes.")
+            self._start_failed = True
+            return None
+        log.debug('started instance %s', v_m._qualified_name)
+        if index == self._config._n_vms_requested - 1:
+            # all nodes started
+            self._times['NODES_STARTED'] = time.time()
+            self._times['SETUP_ELAPSED'] = self._times['SETUP_DONE'] - \
+                self._times['CLUSTER_START']
+            self._times['NODE_START_ELAPSED'] = self._times['NODES_STARTED']\
+                - self._times['SETUP_DONE']
+            self._times['CLUSTER_START_ELAPSED'] = \
+                self._times['SETUP_ELAPSED'] + \
+                self._times['NODE_START_ELAPSED']
+
+            log.debug("setup time: %.1f sec", self._times['SETUP_ELAPSED'])
+            log.debug("node start time: %.1f sec (%.1f sec per vm)",
+                      self._times['NODE_START_ELAPSED'],
+                      self._times['NODE_START_ELAPSED'] /
+                      self._config._n_vms_requested)
+            log.debug("total cluster start time: %.1f sec (%.1f sec per vm)",
+                      self._times['CLUSTER_START_ELAPSED'],
+                      self._times['CLUSTER_START_ELAPSED'] /
+                      self._config._n_vms_requested)
+            # pause here to try to address the fact that Ansible setup fails
+            # more often on the first try than subsequent tries
+            time.sleep(_retry_sleep())
+        self._save_or_update()  # store our state
+        return v_m._qualified_name
+
+    def stop_instance(self, instance_id):
+        """Stops the instance gracefully.
+
+        :param str instance_id: instance identifier
+
+        :return: None
+        """
+        self._restore_from_storage(instance_id)
+        if self._start_failed:
+            raise Exception('stop_instance for node %s: failing due to'
+                            ' previous errors.' % instance_id)
+
+        with self._resource_lock:
+            try:
+                v_m = self._qualified_name_to_vm(instance_id)
+                if not v_m:
+                    err = "stop_instance: can't find instance %s" % instance_id
+                    log.error(err)
+                    raise Exception(err)
+                v_m._cloud_service._stop_vm(v_m)
+                # note: self._n_instances is a derived property, doesn't need
+                # to be updated
+                if self._n_instances == 0:
+                    log.debug('last instance deleted, destroying '
+                              'global resources')
+                    self._delete_global_reqs()
+                    self._delete_cloud_provider_storage()
+            except Exception as exc:
+                log.error(traceback.format_exc())
+                log.error("error stopping instance %s: %s", instance_id, exc)
+                raise
+        log.debug('stopped instance %s', instance_id)
+
+    def get_ips(self, instance_id):
+        """Retrieves the private and public ip addresses for a given instance.
+        Note: Azure normally provides access to vms from a shared load
+        balancer IP and
+        mapping of ssh ports on the vms. So by default, the Azure provider
+        returns strings
+        of the form 'ip:port'. However, 'stock' elasticluster and ansible
+        don't support this,
+        so _use_public_ips uses Azure PublicIPs to expose each vm on the
+        internet with its own IP
+        and using the standard SSH port.
+
+        :return: list (IPs)
+        """
+        self._restore_from_storage(instance_id)
+        if self._start_failed:
+            raise Exception('get_ips for node %s: failing due to'
+                            ' previous errors.' % instance_id)
+
+        ret = list()
+        v_m = self._qualified_name_to_vm(instance_id)
+        if not v_m:
+            raise Exception("Can't find instance_id %s" % instance_id)
+        if self._config._use_public_ips:
+            ret.append(v_m._public_ip)
+        else:
+            ret.append("%s:%s" % (v_m._public_ip, v_m._ssh_port))
+
+        log.debug('get_ips (instance %s) returning %s',
+                  instance_id, ', '.join(ret))
+        return ret
+
+    def is_instance_running(self, instance_id):
+        """Checks if the instance is up and running.
+
+        :param str instance_id: instance identifier
+
+        :return: bool - True if running, False otherwise
+        """
+        self._restore_from_storage(instance_id)
+        if self._start_failed:
+            raise Exception('is_instance_running for node %s: failing due to'
+                            ' previous errors.' % instance_id)
+        try:
+            v_m = self._qualified_name_to_vm(instance_id)
+            if not v_m:
+                raise Exception("Can't find instance_id %s" % instance_id)
+        except Exception:
+            log.error(traceback.format_exc())
+            raise
+        return v_m._power_state == 'Started'
+
+    # ------------------ add-on methods ---------------------------------
+    # (not part of the base class, but useful extensions)
+
+    # -------------------- private members ------------------------------
+
+    @property
+    def _resource_lock(self):
+        if self._resource_lock_internal is None:
+            self._resource_lock_internal = threading.Lock()
+        return self._resource_lock_internal
+
+    @property
+    def _n_instances(self):
+        ret = 0
+        for subscription in self._subscriptions:
+            ret = ret + subscription._n_instances
+        return ret
+
+    def _qualified_name_to_vm(self, qualified_name):
+        i_sub, i_cs, _, _, _ = \
+            self._config._vm_name_to_resources(qualified_name)
+        c_s = self._subscriptions[i_sub]._cloud_services[i_cs]
+        with c_s._resource_lock:
+            return c_s._instances[qualified_name]
+
+    def _create_global_reqs(self):
+        try:
+            for index in range(self._config._n_cloud_services):
+                i_sub = floor_div(index, self._config._cs_per_sub)
+                sub = self._subscriptions[i_sub]
+                acs = AzureCloudService(self._config, sub, index)
+                acs._create()
+                acs._add_certificate()
+                log.debug("Created cloud service %i (%s)", index, acs._name)
+                sub._cloud_services.append(acs)
+
+            for index in range(self._config._n_storage_accounts):
+                i_sub = floor_div(index, self._config._sa_per_sub)
+                sub = self._subscriptions[i_sub]
+                asa = AzureStorageAccount(self._config, sub, index)
+                asa._create()
+                log.debug("Created storage account %i (%s)", index, asa._name)
+                sub._storage_accounts.append(asa)
+
+            # one vnet should be enough for ~ 1000 vms. Tie it to
+            # the first subscription.
+            # NOTE: this doesn't work - can't start a vm in sub B
+            # that refers to a vnet in sub A.
+            # sub = self._subscriptions[0]
+            # sub._vnet = AzureVNet(self._config, sub, 0)
+            # sub._vnet._create()
+            index = 0
+            for sub in self._subscriptions:
+                sub._vnet = AzureVNet(self._config, sub, index)
+                sub._vnet._create()
+                index += 1
+        except Exception as exc:
+            log.error('_create_global_reqs error: %s', exc)
+            log.debug("setting start_failed flag. Will not "
+                      "try to start further nodes.")
+            self._start_failed = True
+            raise
+
+    # tear down non-node-specific resources. Current default is to delete
+    # everything; this may change.
+    #
+    def _delete_global_reqs(self):
+        try:
+            # delete all the OS VHDs
+            while self._disks_to_delete:
+                for disk_name, disk_info in self._disks_to_delete.items():
+                    if disk_info['TRIES'] >= VHD_DELETE_ATTEMPTS:
+                        log.error("failed to delete vhd %s after %i attempts. "
+                                  "giving up.", disk_name, disk_info['TRIES'])
+                        del self._disks_to_delete[disk_name]
+                        continue
+                    if self._delete_disk(disk_name, disk_info):
+                        del self._disks_to_delete[disk_name]
+                time.sleep(5)
+
+            for sub in self._subscriptions:
+                for c_s in sub._cloud_services:
+                    if c_s._instances:
+                        err = "cloud service %s can't be destroyed, it " \
+                              "still has %i vms." % \
+                              (c_s._name, len(c_s._instances))
+                        log.error(err)
+                        raise Exception(err)
+                    c_s._delete()
+                    log.debug("Deleted cloud service '%s'", c_s._name)
+
+                for s_a in sub._storage_accounts:
+                    s_a._delete()
+                    log.debug("Deleted storage account '%s'", s_a._name)
+
+                sub._vnet._delete()
+        except Exception as exc:
+            log.error('_delete_global_reqs error: %s', exc)
+            raise
+
+    def _delete_disk(self, disk_name, disk_info):
+        disk_info['TRIES'] += 1
+        if disk_info['TRIES'] > VHD_DELETE_ATTEMPTS:
+            return False
+        sms = disk_info['SMS']
+        now = time.time()
+        if disk_info['LATEST_TRY'] and \
+                (now - disk_info['LATEST_TRY'] < VHD_DELETE_INTERVAL):
+            return False
+        disk_info['LATEST_TRY'] = now
+        try:
+            # delete_vhd=False doesn't seem to help if the disk is not
+            # ready to be deleted yet
+            sms.delete_disk(disk_name=disk_name, delete_vhd=True)
+            log.debug('_delete_vhd %s: success on attempt %i',
+                      disk_name, disk_info['TRIES'])
+            return True
+        except Exception as exc:
+            if str(exc) == 'Not found (Not Found)':
+                log.debug(
+                    "_delete_vhd: 'not found' deleting %s, assuming "
+                    "success", disk_name)
+                return True
+            # log.error('_delete_vhd: error on attempt #%i to delete '
+            #          'disk %s: %s' % (disk_info['TRIES'], disk_name, exc))
+            return False
+
+    # methods to support saving and loading our (i.e. cloud provider's) state
+
+    def _save_or_update(self):
+        """Save or update the private state needed by the cloud provider.
+        """
+        with self._resource_lock:
+            if not self._config or not self._config._storage_path:
+                raise Exception("self._config._storage path is undefined")
+            if not self._config._base_name:
+                raise Exception("self._config._base_name is undefined")
+            if not os.path.exists(self._config._storage_path):
+                os.makedirs(self._config._storage_path)
+            path = self._get_cloud_provider_storage_path()
+            with open(path, 'wb') as storage:
+                pickle.dump(self._config, storage, pickle.HIGHEST_PROTOCOL)
+                pickle.dump(self._subscriptions, storage,
+                            pickle.HIGHEST_PROTOCOL)
+
+    def _get_cloud_provider_storage_path(self):
+        cluster_file = 'azure_%s.pickle' % self._config._base_name
+        return os.path.join(self._config._storage_path, cluster_file)
+
+    def _delete_cloud_provider_storage(self):
+        full_path = None
+        try:
+            cluster_file = 'azure_%s.pickle' % self._config._base_name
+            full_path = os.path.join(self._config._storage_path, cluster_file)
+            if os.path.isfile(full_path):
+                os.remove(full_path)
+        except Exception as exc:
+            log.error("Unable to delete storage file %s: %s", full_path, exc)
+
+    # when cluster provider method called, all we know is an instance name.
+    def _restore_from_storage(self, instance_name):
+        with self._resource_lock:
+            if self._config._base_name:
+                return  # our state is intact, don't load
+            if not self._config._storage_path:
+                raise Exception("self._config._storage_path is undefined")
+            self._config._base_name, _, _ = instance_name.partition('_')
+            path = self._get_cloud_provider_storage_path()
+            if not os.path.exists(path):
+                raise Exception("cloud provider storage file %s not "
+                                "found" % path)
+            with open(path, 'r') as storage:
+                self._config = pickle.load(storage)
+                self._subscriptions = pickle.load(storage)
+                # fix up circular references
+                self._config._parent = self
+                for sub in self._subscriptions:
+                    for clds in sub._cloud_services:
+                        clds._config = self._config
+                        clds._subscription = sub
+                    for stac in sub._storage_accounts:
+                        stac._config = self._config
+                        stac._subscription = sub
+
+    # methods to support pickling by elasticluster
+
+    def __getstate__(self):
+        dct = self.__dict__.copy()
+        del dct['_resource_lock_internal']
+        del dct['_start_failed']
+        return dct
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self._resource_lock_internal = None
+        self._start_failed = False

--- a/elasticluster/providers/ec2_boto.py
+++ b/elasticluster/providers/ec2_boto.py
@@ -103,6 +103,9 @@ class BotoCloudProvider(AbstractCloudProvider):
         if self._ec2_connection:
             return self._ec2_connection
 
+        if not self._vpc:
+            vpc_connection = None
+
         try:
             log.debug("Connecting to ec2 host %s", self._ec2host)
             region = ec2.regioninfo.RegionInfo(name=self._region_name,

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ required_packages = [
     'PyCLI',
     'pycrypto',
     'paramiko',
-    'ansible',
+    'ansible==1.7.2',
+    'azure',
     'voluptuous',
     'configobj',
     # EC2 clouds


### PR DESCRIPTION
Add Microsoft Azure as a cloud provider for elasticluster. Changes consist of:
1. The Azure provider itself (providers/azure_provider.py). This inherits from 
   AbstractCloudProvider like the others. It pulls in a dependency on the Azure SDK
   for Python (https://github.com/Azure/azure-sdk-for-python).
2. Changes to add Azure to the set of providers that can be specified. This is 
   in **init**.py and conf.py.
3. Changes to allow elasticluster to support nonstandard ssh ports on virtual machines.
   This is needed because when an Azure cluster is created, all the nodes are reached through
   a load balancer, so they all have the same public IP. The ssh ports are mapped so that
   each VM can be reached using a different port number. Elasticluster doesn't natively
   support this, so changes were made to cluster.py, subcommands.py, and 
   providers/ansible_provider.py. (Ansible itself supports this without modification.)
4. Documentation: README-AZURE.rst, and azure-sample-config.

All functionality with non-Azure clouds should work exactly as before.
